### PR TITLE
Correctly handle strings with dollar signs (and anything else, if I've gotten it right)

### DIFF
--- a/lib/pg_hstore.rb
+++ b/lib/pg_hstore.rb
@@ -21,22 +21,28 @@ module PgHstore
     end
   end
 
-  # set for_parameter = true if you're using the output for a bind variable
-  def PgHstore.dump(hash, for_parameter = false)
-    memo = hash.map do |k, v|
-      if v.nil?
-        v = "NULL"
-      else
-        v = DOUBLE_QUOTE + escape(v) + DOUBLE_QUOTE
-      end
-      k = DOUBLE_QUOTE + escape(k) + DOUBLE_QUOTE
-      [k, v].join HASHROCKET
-    end.join COMMA
-    if for_parameter
-      memo
-    else
-      as_postgresql_string_constant(memo)
-    end
+  # Serialize a hash to be sent to PostgreSQL as an hstore value.
+  #
+  # By default, returns a (Postgre)SQL string constant suitable for
+  # interpolating directly into a query.  With raw_string = true,
+  # returns the plain string value suitable for use as a bind variable.
+  def PgHstore.dump(hash, raw_string = false)
+    # Per http://www.postgresql.org/docs/9.2/static/hstore.html :
+    #
+    #   The text representation of an hstore, used for input and
+    #   output, includes zero or more 'key => value' pairs separated
+    #   by commas. [...] Whitespace between pairs or around the =>
+    #   sign is ignored.  Double-quote keys and values [... see
+    #   escape_nonnull_for_hstore ...]
+    #
+    #   A value (but not a key) can be an SQL NULL.  Double-quote the
+    #   NULL to treat it as the ordinary string "NULL".
+    hstore = hash.map do |k, v|
+      hstore_k = escape_nonnull_for_hstore(k)
+      hstore_v = (v.nil?) ? "NULL" : escape_nonnull_for_hstore(v)
+      [hstore_k, hstore_v].join(HASHROCKET)
+    end.join(COMMA)
+    raw_string ? hstore : as_postgresql_string_constant(hstore)
   end
 
   class << self
@@ -59,14 +65,24 @@ module PgHstore
   def PgHstore.unescape(literal)
     literal.gsub ESCAPED_CHAR, '\1'
   end
-  
-  NON_ESCAPE_SLASH = '\\'
-  ESCAPED_SLASH = '\\\\'
-  ESCAPED_DOUBLE_QUOTE = '\"'
-  def PgHstore.escape(string)
-    string.to_s.gsub(NON_ESCAPE_SLASH) {ESCAPED_SLASH}.gsub DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE
+
+  # Escape a value as a string to use as an hstore key or value.
+  #
+  # Per http://www.postgresql.org/docs/9.2/static/hstore.html :
+  #
+  #   Double-quote keys and values that include [stuff]. To include a
+  #   double quote or a backslash in a key or value, escape it with a
+  #   backslash.
+  #
+  # You got it, boss.
+  def PgHstore.escape_nonnull_for_hstore(string)
+    interior = string.to_s.gsub('\\') {'\\\\'}.gsub('"', '\\"')
+    '"' + interior + '"'
   end
 
+  # Escape a string as a string constant to be used in a SQL query
+  # to PostgreSQL.
+  #
   # Ideally we would use plain SQL string constants, which are very simple:
   #   http://www.postgresql.org/docs/9.2/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
   # Unfortunately PostgreSQL treats these differently depending on the

--- a/lib/pg_hstore.rb
+++ b/lib/pg_hstore.rb
@@ -13,7 +13,6 @@ module PgHstore
   # set symbolize_keys = false if you want string keys
   # thanks to https://github.com/engageis/activerecord-postgres-hstore for regexps!
   def PgHstore.load(hstore, symbolize_keys = true)
-    hstore = unquote hstore, DOLLAR_QUOTE
     hstore.scan(PAIR).inject({}) do |memo, (k, v)|
       k = unescape unquote(k, DOUBLE_QUOTE)
       k = k.to_sym if symbolize_keys

--- a/spec/pg_hstore_spec.rb
+++ b/spec/pg_hstore_spec.rb
@@ -17,27 +17,27 @@ describe "hstores from hashes" do
     ["should translate into a sequel literal",
      {:a => "b", :foo => "bar"},
      '"a"=>"b","foo"=>"bar"',
-     %{$$"a"=>"b","foo"=>"bar"$$} #"
+     %{E'"a"=>"b","foo"=>"bar"'}
     ],
     ["should store an empty string",
      {:nothing => ""},
      '"nothing"=>""',
-     %{$$"nothing"=>""$$} #"
+     %{E'"nothing"=>""'}
     ],
     ["should support single quotes in strings",
      {:journey => "don't stop believin'"},
      %q{"journey"=>"don't stop believin'"},
-     %q{$$"journey"=>"don't stop believin'"$$} #"
+     %q{E'"journey"=>"don\'t stop believin\'"'}
     ],
     ["should support double quotes in strings",
      {:journey => 'He said he was "ready"'},
      %q{"journey"=>"He said he was \"ready\""},
-     %q{$$"journey"=>"He said he was \"ready\""$$} #"
+     %q{E'"journey"=>"He said he was \\\"ready\\\""'}
     ],
     ["should escape \\ garbage in strings",
      {:line_noise => %q[perl -p -e 's/\$\{([^}]+)\}/]}, #'
      %q["line_noise"=>"perl -p -e 's/\\\\$\\\\{([^}]+)\\\\}/"],
-     %q[$$"line_noise"=>"perl -p -e 's/\\\\$\\\\{([^}]+)\\\\}/"$$] #'
+     %q[E'"line_noise"=>"perl -p -e \'s/\\\\\\\\$\\\\\\\\{([^}]+)\\\\\\\\}/"']
     ],
   ]
 

--- a/spec/pg_hstore_spec.rb
+++ b/spec/pg_hstore_spec.rb
@@ -62,6 +62,7 @@ describe "hstores from hashes" do
     { :e1 => "\\'\\''\"" },
     { :f => '\\\"\\""\\' },
     { :g => "\\\'\\''\\" },
+    { :h => "$$; SELECT 'lol=>lol' AS hstore; --"},
     { :z => "');DROP SCHEMA public;--"},
   ]
 

--- a/spec/pg_hstore_spec.rb
+++ b/spec/pg_hstore_spec.rb
@@ -78,7 +78,9 @@ describe "hstores from hashes" do
 
   it "should produce stuff that postgres really likes" do
     require 'pg'
-    uri = URI.parse "postgres://#{`whoami`.strip}:@0.0.0.0:5432/pg_hstore_test"
+    require 'uri'
+    default_uri = "postgres://#{`whoami`.strip}:@0.0.0.0:5432/pg_hstore_test"
+    uri = URI.parse (ENV['PG_HSTORE_TEST_DB_URI'] || default_uri)
     config = {
       host: uri.host,
       port: uri.port,
@@ -87,7 +89,7 @@ describe "hstores from hashes" do
       password: uri.password,
     }
     conn = PG::Connection.new config
-    conn.exec "CREATE EXTENSION IF NOT EXISTS hstore"
+    # conn.exec "CREATE EXTENSION IF NOT EXISTS hstore"
     # conn.exec "SET standard_conforming_strings=on"
     NASTY.each do |data|
       rs = conn.exec %{SELECT $1::hstore AS hstore}, [PgHstore.dump(data, true)]

--- a/spec/pg_hstore_spec.rb
+++ b/spec/pg_hstore_spec.rb
@@ -69,7 +69,7 @@ describe "hstores from hashes" do
     NASTY.each do |data|
       original = data
       3.times do
-        hstore = PgHstore::dump data
+        hstore = PgHstore::dump(data, true)
         data = PgHstore::parse(hstore)
         data.should == original
       end
@@ -111,20 +111,20 @@ describe "hstores from hashes" do
 
   it "should be able to parse hstore strings without ''" do
     data = { :journey => 'He said he was ready' }
-    literal = PgHstore::dump data
-    parsed = PgHstore.parse(literal[2..-3])
+    literal = PgHstore::dump(data, true)
+    parsed = PgHstore.parse(literal)
     parsed.should == data
   end
 
   it "should be stable over iteration" do
-    dump = PgHstore::dump :journey => 'He said he was "ready"'
+    dump = PgHstore::dump({:journey => 'He said he was "ready"'}, true)
     parse = PgHstore::parse dump
 
     original = dump
 
     10.times do
       parsed = PgHstore::parse(dump)
-      dump = PgHstore::dump(parsed)
+      dump = PgHstore::dump(parsed, true)
       dump.should == original
     end
   end

--- a/spec/pg_hstore_spec.rb
+++ b/spec/pg_hstore_spec.rb
@@ -13,6 +13,11 @@ describe "hstores from hashes" do
     hstore[:ip].should == ""
   end
 
+  it "should parse NULL as a value" do
+    hstore = PgHstore.parse(%{"x"=>NULL})
+    hstore.should == {x: nil}
+  end
+
   DATA = [
     ["should translate into a sequel literal",
      {:a => "b", :foo => "bar"},
@@ -23,6 +28,11 @@ describe "hstores from hashes" do
      {:nothing => ""},
      '"nothing"=>""',
      %{E'"nothing"=>""'}
+    ],
+    ["should render nil as NULL",
+     {:x => nil},
+     '"x"=>NULL',
+     %{E'"x"=>NULL'}
     ],
     ["should support single quotes in strings",
      {:journey => "don't stop believin'"},

--- a/spec/pg_hstore_spec.rb
+++ b/spec/pg_hstore_spec.rb
@@ -97,6 +97,16 @@ describe "hstores from hashes" do
       rs = conn.exec %{SELECT #{PgHstore.dump(data)}::hstore AS hstore}
       PgHstore.load(rs[0]['hstore']).should == data
     end
+    DATA.each do |name, hash, encoded, string_constant|
+      # Already tested PgHstore.dump produces what we expect for these,
+      # so test that what we expect is acceptable to PostgreSQL.
+      ret = conn.exec(%{SELECT $1::hstore AS hstore}, [encoded])[0]['hstore']
+      ret.should == encoded.gsub(',', ', ')
+      PgHstore.load(ret).should == hash
+      ret = conn.exec(%{SELECT #{string_constant}::hstore AS hstore})[0]['hstore']
+      ret.should == encoded.gsub(',', ', ')
+      PgHstore.load(ret).should == hash
+    end
   end
 
   it "should be able to parse hstore strings without ''" do

--- a/spec/pg_hstore_spec.rb
+++ b/spec/pg_hstore_spec.rb
@@ -1,23 +1,15 @@
 require './lib/pg_hstore'
 
 describe "hstores from hashes" do
-  before do
-    @h = PgHstore::dump :a => "b", :foo => "bar"
-  end
-
   it "should translate into a sequel literal" do
-    @h.should == %{$$"a"=>"b","foo"=>"bar"$$}
-  end
-end
-
-describe "creating hstores from strings" do
-  before do
-    @h = PgHstore::parse (
-      %{"ip"=>"17.34.44.22", "service_available?"=>"false"})
+    h = PgHstore::dump :a => "b", :foo => "bar"
+    h.should == %{$$"a"=>"b","foo"=>"bar"$$}
   end
 
   it "should set a value correctly" do
-    @h[:service_available?].should == "false"
+    h = PgHstore::parse (
+      %{"ip"=>"17.34.44.22", "service_available?"=>"false"})
+    h[:service_available?].should == "false"
   end
 
   it "should store an empty string" do


### PR DESCRIPTION
As a comment suggests, the current version can produce the wrong result in some cases. This bug can be turned into an injection if a user can cause one of the values in the hash to contain a double dollar sign, looking something like

```
$$; SELECT 'lol'; --
```

In this series, we reorganize the tests, then add a test for this bug; fix the bug; and refactor the code a bit and add extensive comments referring to the PostgreSQL docs to document why it all works.

To fix the bug, we replace dollar-quoting with a different PostgreSQL string constant syntax, one that I believe I've used 100% correctly here so that there are no more injections.
