### PR TITLE
Adding license info to the gemspec.

### DIFF
--- a/pg-hstore.gemspec
+++ b/pg-hstore.gemspec
@@ -1,6 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'pg-hstore'
   s.version = '1.2.0'
+  s.license = 'MIT'
 
   s.description = "postgresql hstore parser/deparser - provides PgHstore.dump and PgHstore.load (aka parse)"
   s.summary     = "postgresql hstore parser/deparser - provides PgHstore.dump and PgHstore.load (aka parse)"


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.